### PR TITLE
[JB][OPS-13723]

### DIFF
--- a/app/uk/gov/hmrc/cardpaymentfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/actions/Actions.scala
@@ -24,12 +24,15 @@ import javax.inject.{Inject, Singleton}
 class Actions @Inject() (
     actionBuilder:                DefaultActionBuilder,
     getJourneyActionRefiner:      GetJourneyActionRefiner,
-    journeyFinishedActionRefiner: JourneyFinishedActionRefiner
+    journeyFinishedActionRefiner: JourneyFinishedActionRefiner,
+    paymentStatusActionRefiner:   PaymentStatusActionRefiner
 ) {
 
   val default: ActionBuilder[Request, AnyContent] = actionBuilder
 
   val journeyAction: ActionBuilder[JourneyRequest, AnyContent] = default.andThen[JourneyRequest](getJourneyActionRefiner)
+
+  val paymentStatusAction: ActionBuilder[JourneyRequest, AnyContent] = journeyAction.andThen[JourneyRequest](paymentStatusActionRefiner)
 
   val journeyFinishedAction: ActionBuilder[JourneyRequest, AnyContent] = journeyAction.andThen[JourneyRequest](journeyFinishedActionRefiner)
 

--- a/app/uk/gov/hmrc/cardpaymentfrontend/actions/PaymentStatusActionRefiner.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/actions/PaymentStatusActionRefiner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,24 @@
 
 package uk.gov.hmrc.cardpaymentfrontend.actions
 
+import payapi.corcommon.model.PaymentStatuses
 import play.api.Logging
 import play.api.mvc.{ActionRefiner, Result, Results}
+import uk.gov.hmrc.cardpaymentfrontend.util.SafeEquals.EqualsOps
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class JourneyFinishedActionRefiner @Inject() ()(implicit ec: ExecutionContext) extends ActionRefiner[JourneyRequest, JourneyRequest] with Logging {
+class PaymentStatusActionRefiner @Inject() ()(implicit ec: ExecutionContext) extends ActionRefiner[JourneyRequest, JourneyRequest] with Logging {
 
+  //we don't want to be calling payment status again if we know that the journey is already in finished state
   override protected[actions] def refine[A](request: JourneyRequest[A]): Future[Either[Result, JourneyRequest[A]]] = {
-    if (request.journey.status.isTerminalState) Future.successful(Right(request))
-    else Future.successful(Left(Results.NotFound("Journey not in valid state")))
+    if (request.journey.status === PaymentStatuses.Sent) Future.successful(Right(request))
+    else {
+      logger.warn(s"Trying to call payment status endpoint when journey is in state [${request.journey.status.entryName}], but it should be in state [Sent]")
+      Future.successful(Left(Results.NotFound("Journey not in valid state")))
+    }
   }
 
   override protected def executionContext: ExecutionContext = ec

--- a/app/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentCompleteController.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentCompleteController.scala
@@ -25,9 +25,7 @@ import uk.gov.hmrc.cardpaymentfrontend.actions.{Actions, JourneyRequest}
 import uk.gov.hmrc.cardpaymentfrontend.models.extendedorigins.ExtendedOrigin.OriginExtended
 import uk.gov.hmrc.cardpaymentfrontend.models.{EmailAddress, creditCardCommissionRate}
 import uk.gov.hmrc.cardpaymentfrontend.requests.RequestSupport
-import uk.gov.hmrc.cardpaymentfrontend.services.EmailService
 import uk.gov.hmrc.cardpaymentfrontend.session.JourneySessionSupport._
-import uk.gov.hmrc.cardpaymentfrontend.util.SafeEquals.EqualsOps
 import uk.gov.hmrc.cardpaymentfrontend.utils.DateStringBuilder
 import uk.gov.hmrc.cardpaymentfrontend.views.html.PaymentCompletePage
 import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, Text, Value}
@@ -35,15 +33,13 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListR
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
 
 class PaymentCompleteController @Inject() (
     actions:             Actions,
-    emailService:        EmailService,
     mcc:                 MessagesControllerComponents,
     paymentCompletePage: PaymentCompletePage,
     requestSupport:      RequestSupport
-)(implicit executionContext: ExecutionContext) extends FrontendController(mcc) {
+) extends FrontendController(mcc) {
 
   import requestSupport._
 
@@ -51,17 +47,6 @@ class PaymentCompleteController @Inject() (
 
     val maybeEmailFromSession: Option[EmailAddress] =
       journeyRequest.readFromSession[EmailAddress](journeyRequest.journeyId, Keys.email).filter(!_.value.isBlank).map(email => EmailAddress(email.value))
-
-    val langIsEnglish: Boolean = journeyRequest.lang.code =!= "cy"
-
-    //TODO: Eventually we can call this from the payment-status controller, but we don't have that yet.
-    val _ = maybeEmailFromSession.fold(Future.unit) { email =>
-      emailService.sendEmail(
-        journey      = journeyRequest.journey,
-        emailAddress = email,
-        isEnglish    = langIsEnglish
-      )(RequestSupport.hc, journeyRequest)
-    }.map((_: Unit) => ())
 
     Ok(paymentCompletePage(
       taxReference      = journeyRequest.journey.getReference,

--- a/app/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentStatusController.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentStatusController.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.cardpaymentfrontend.models.cardpayment.CardPaymentFinishPayme
 import uk.gov.hmrc.cardpaymentfrontend.requests.RequestSupport
 import uk.gov.hmrc.cardpaymentfrontend.services.CardPaymentService
 import uk.gov.hmrc.cardpaymentfrontend.views.html.iframe.{IframeContainerPage, RedirectToParentPage}
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrl.idFunctor
 import uk.gov.hmrc.play.bootstrap.binders.RedirectUrlPolicy.Id
 import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, RedirectUrl, RedirectUrlPolicy}
@@ -62,9 +61,8 @@ class PaymentStatusController @Inject() (
   }
 
   //todo append something to the return url so we can extract/work out the session/journey - are we allowed to do this or do we use session?
-  def paymentStatus(): Action[AnyContent] = actions.journeyAction.async { implicit journeyRequest =>
+  def paymentStatus(): Action[AnyContent] = actions.paymentStatusAction.async { implicit journeyRequest =>
 
-    implicit val hc: HeaderCarrier = requestSupport.hc
     val transactionRefFromJourney: Option[String] = journeyRequest.journey.order.map(_.transactionReference.value)
 
     val maybeCardPaymentResultF = for {

--- a/app/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentService.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentService.scala
@@ -99,14 +99,11 @@ class CardPaymentService @Inject() (
       cardPaymentResult = result.json.asOpt[CardPaymentResult]
       maybeWebPaymentRequest: Option[FinishedWebPaymentRequest] = cardPaymentResult.flatMap(cardPaymentResultIntoUpdateWebPaymentRequest)
       _ <- maybeWebPaymentRequest.fold(payApiConnector.JourneyUpdates.updateCancelWebPayment(journeyId)) {
-        case r: FailWebPaymentRequest => payApiConnector.JourneyUpdates.updateFailWebPayment(journeyId, r)
+        case r: FailWebPaymentRequest =>
+          payApiConnector.JourneyUpdates.updateFailWebPayment(journeyId, r)
         case r: SucceedWebPaymentRequest =>
-          payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r).map(_ => maybeSendEmailF())
-        //
-        //          for {
-        //            _ <- payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r)
-        //            _ <- maybeSendEmailF()
-        //          } yield ()
+          payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r)
+            .map(_ => maybeSendEmailF())
       }
     } yield cardPaymentResult
   }

--- a/app/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentService.scala
+++ b/app/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentService.scala
@@ -17,14 +17,18 @@
 package uk.gov.hmrc.cardpaymentfrontend.services
 
 import payapi.cardpaymentjourney.model.journey.Journey
-import payapi.corcommon.model.TransNumberGenerator
+import payapi.corcommon.model.{PaymentStatuses, TransNumberGenerator}
 import play.api.Logging
-import play.api.libs.json.JsBoolean
+import play.api.i18n.MessagesApi
+import uk.gov.hmrc.cardpaymentfrontend.actions.JourneyRequest
 import uk.gov.hmrc.cardpaymentfrontend.config.AppConfig
 import uk.gov.hmrc.cardpaymentfrontend.connectors.{CardPaymentConnector, PayApiConnector}
 import uk.gov.hmrc.cardpaymentfrontend.models.cardpayment.{BarclaycardAddress, CardPaymentFinishPaymentResponses, CardPaymentInitiatePaymentRequest, CardPaymentInitiatePaymentResponse, CardPaymentResult, ClientId}
 import uk.gov.hmrc.cardpaymentfrontend.models.payapi.{BeginWebPaymentRequest, FailWebPaymentRequest, FinishedWebPaymentRequest, SucceedWebPaymentRequest}
 import uk.gov.hmrc.cardpaymentfrontend.models.{Address, EmailAddress, Language}
+import uk.gov.hmrc.cardpaymentfrontend.requests.RequestSupport
+import uk.gov.hmrc.cardpaymentfrontend.session.JourneySessionSupport.{Keys, RequestOps}
+import uk.gov.hmrc.cardpaymentfrontend.util.SafeEquals.EqualsOps
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.{Clock, LocalDateTime}
@@ -35,11 +39,15 @@ import scala.concurrent.{ExecutionContext, Future}
 class CardPaymentService @Inject() (
     appConfig:            AppConfig,
     cardPaymentConnector: CardPaymentConnector,
+    clientIdService:      ClientIdService,
     clock:                Clock,
+    emailService:         EmailService,
     payApiConnector:      PayApiConnector,
-    transNoGenerator:     TransNumberGenerator,
-    clientIdService:      ClientIdService
+    requestSupport:       RequestSupport,
+    transNoGenerator:     TransNumberGenerator
 )(implicit executionContext: ExecutionContext) extends Logging {
+
+  import requestSupport._
 
   // the url barclaycard make an empty post to after user completes payment
   private def returnToHmrcUrl: String =
@@ -82,18 +90,23 @@ class CardPaymentService @Inject() (
     } yield initiatePaymentResponse
   }
 
-  def checkPaymentStatus(transactionReference: String)(implicit headerCarrier: HeaderCarrier): Future[JsBoolean] = {
-    cardPaymentConnector.checkPaymentStatus(transactionReference)
-  }
-
-  def finishPayment(transactionReference: String, journeyId: String)(implicit headerCarrier: HeaderCarrier): Future[Option[CardPaymentResult]] = {
+  def finishPayment(
+      transactionReference: String,
+      journeyId:            String
+  )(implicit journeyRequest: JourneyRequest[_], messagesApi: MessagesApi): Future[Option[CardPaymentResult]] = {
     for {
       result <- cardPaymentConnector.authAndSettle(transactionReference)
       cardPaymentResult = result.json.asOpt[CardPaymentResult]
       maybeWebPaymentRequest: Option[FinishedWebPaymentRequest] = cardPaymentResult.flatMap(cardPaymentResultIntoUpdateWebPaymentRequest)
       _ <- maybeWebPaymentRequest.fold(payApiConnector.JourneyUpdates.updateCancelWebPayment(journeyId)) {
-        case r: FailWebPaymentRequest    => payApiConnector.JourneyUpdates.updateFailWebPayment(journeyId, r)
-        case r: SucceedWebPaymentRequest => payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r)
+        case r: FailWebPaymentRequest => payApiConnector.JourneyUpdates.updateFailWebPayment(journeyId, r)
+        case r: SucceedWebPaymentRequest =>
+          payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r).map(_ => maybeSendEmailF())
+        //
+        //          for {
+        //            _ <- payApiConnector.JourneyUpdates.updateSucceedWebPayment(journeyId, r)
+        //            _ <- maybeSendEmailF()
+        //          } yield ()
       }
     } yield cardPaymentResult
   }
@@ -111,6 +124,27 @@ class CardPaymentService @Inject() (
         additionalPaymentInfo.cardCategory.getOrElse("debit") //todo check if can this be anything?
       ))
     case CardPaymentResult(CardPaymentFinishPaymentResponses.Cancelled, _) => None
+  }
+
+  /**
+   * If journey is not in completed state (i.e. they've been on the iframe, so sent) and they have an email in session, send an email.
+   * Otherwise return future.unit.
+   */
+  private[services] def maybeSendEmailF()(implicit headerCarrier: HeaderCarrier, journeyRequest: JourneyRequest[_], messagesApi: MessagesApi): Unit = {
+    if (journeyRequest.journey.status === PaymentStatuses.Sent) {
+
+      val maybeEmailFromSession: Option[EmailAddress] =
+        journeyRequest.readFromSession[EmailAddress](journeyRequest.journeyId, Keys.email)
+          .filter(!_.value.isBlank)
+          .map(email => EmailAddress(email.value))
+
+      maybeEmailFromSession.fold(()) { emailAddress =>
+        emailService
+          .sendEmail(journeyRequest.journey, emailAddress, journeyRequest.request.lang.code =!= "cy")(headerCarrier, journeyRequest)
+          .onComplete(_ => ())
+      }
+
+    } else ()
   }
 
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -23,7 +23,7 @@ object AppDependencies {
 
   val test: Seq[ModuleID] = Seq[ModuleID](
     "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion,
-    "org.jsoup"   %  "jsoup"                  % "1.20.1"
+    "org.jsoup"   %  "jsoup"                  % "1.21.1"
   ).map( _ % Test )
 
   val it: Seq[ModuleID] = Seq.empty[ModuleID]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,7 +15,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq[ModuleID](
     "uk.gov.hmrc"  %% "bootstrap-frontend-play-30"       % bootstrapVersion,
-    "uk.gov.hmrc"  %% "play-frontend-hmrc-play-30"       % "12.5.0",
+    "uk.gov.hmrc"  %% "play-frontend-hmrc-play-30"       % "12.6.0",
     "com.beachape" %% "enumeratum"                       % "1.9.0",
     "com.beachape" %% "enumeratum-play"                  % "1.9.0",
     "uk.gov.hmrc"  %% "pay-api-cor-card-payment-journey" % payApiCorVersion excludeAll(payApiExclusionRules *)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 //format: OFF
 object AppDependencies {
 
-  val payApiCorVersion = "1.259.0"
+  val payApiCorVersion = "1.260.0"
   private val bootstrapVersion = "9.13.0"
 
   private val payApiExclusionRules: Seq[InclusionRule] = Seq(

--- a/test/uk/gov/hmrc/cardpaymentfrontend/actions/ActionRefinerSpec.scala
+++ b/test/uk/gov/hmrc/cardpaymentfrontend/actions/ActionRefinerSpec.scala
@@ -63,4 +63,27 @@ class ActionRefinerSpec extends ItSpec {
     }
   }
 
+  "paymentStatusActionRefiner" - {
+    val systemUnderTest: PaymentStatusActionRefiner = app.injector.instanceOf[PaymentStatusActionRefiner]
+
+      def fakeRequest(journey: Journey[JourneySpecificData]): JourneyRequest[AnyContent] = new JourneyRequest(journey, FakeRequest())
+
+    "should return a left when journey in JourneyRequest is not in sent state - Finished" in {
+      val request = fakeRequest(TestJourneys.PfSa.journeyAfterSucceedDebitWebPayment)
+      systemUnderTest.refine(request).futureValue shouldBe Left(Results.NotFound("Journey not in valid state"))
+    }
+
+    "should return a left when journey in JourneyRequest is not in sent state - Created" in {
+      val request = fakeRequest(TestJourneys.PfSa.journeyBeforeBeginWebPayment)
+      systemUnderTest.refine(request).futureValue shouldBe Left(Results.NotFound("Journey not in valid state"))
+    }
+
+    "should return a right when journey in JourneyRequest is in sent state" in {
+      val request = fakeRequest(TestJourneys.PfSa.journeyAfterBeginWebPayment)
+      val result: Either[Result, JourneyRequest[AnyContent]] = systemUnderTest.refine(request).futureValue
+      result.isRight shouldBe true
+      result.map(_.journey) shouldBe Right(TestJourneys.PfSa.journeyAfterBeginWebPayment)
+    }
+  }
+
 }

--- a/test/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentCompleteControllerSpec.scala
+++ b/test/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentCompleteControllerSpec.scala
@@ -24,13 +24,11 @@ import payapi.cardpaymentjourney.model.journey.{Journey, JourneySpecificData, Ur
 import payapi.corcommon.model.barclays.{CardCategories, TransactionReference}
 import payapi.corcommon.model.{AmountInPence, JourneyId, Origin, Origins}
 import play.api.i18n.{Messages, MessagesApi}
-import play.api.libs.json.Json
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.mvc.Http.Status
 import uk.gov.hmrc.cardpaymentfrontend.controllers.PaymentCompleteControllerSpec.{TestScenarioInfo, originToTdAndSummaryListRows}
-import uk.gov.hmrc.cardpaymentfrontend.models.EmailAddress
 import uk.gov.hmrc.cardpaymentfrontend.testsupport.TestOps._
 import uk.gov.hmrc.cardpaymentfrontend.testsupport.stubs.{EmailStub, PayApiStub}
 import uk.gov.hmrc.cardpaymentfrontend.testsupport.testdata.TestJourneys
@@ -51,24 +49,6 @@ class PaymentCompleteControllerSpec extends ItSpec {
     val fakeGetRequestInWelsh: FakeRequest[AnyContentAsEmpty.type] = fakeGetRequest.withLangWelsh()
 
     "GET /payment-complete" - {
-
-      val jsonBody = Json.parse(
-
-        """
-        {
-          "to" : [ "blah@blah.com" ],
-          "templateId" : "payment_successful",
-          "parameters" : {
-            "taxType" : "Self Assessment",
-            "taxReference" : "1234567895K",
-            "paymentReference" : "Some-transaction-ref",
-            "amountPaid" : "12.34",
-            "totalPaid" : "12.34"
-          },
-          "force" : false
-        }
-        """
-      )
 
       "render the page with the language toggle" in {
         PayApiStub.stubForFindBySessionId2xx(TestJourneys.PfSa.journeyAfterSucceedDebitWebPayment)
@@ -191,20 +171,11 @@ class PaymentCompleteControllerSpec extends ItSpec {
         surveyWrapper.select("#survey-link-wrapper").html() shouldBe """<a class="govuk-link" href="/pay-by-card/start-payment-survey">Rhowch wybod i ni beth yw eich barn am y gwasanaeth hwn</a> (mae’n cymryd 30 eiliad)"""
       }
 
-      //this test will be moved eventually
-      "should send an email if there is one in the session" in {
-        PayApiStub.stubForFindBySessionId2xx(TestJourneys.PfSa.journeyAfterSucceedDebitWebPayment)
-        val fakeRequestForTest = fakeGetRequest.withEmailInSession(TestJourneys.PfSa.journeyAfterSucceedDebitWebPayment._id, EmailAddress("blah@blah.com"))
-        val result = systemUnderTest.renderPage(fakeRequestForTest)
-        status(result) shouldBe Status.OK
-        EmailStub.verifyEmailWasSent(jsonBody)
-      }
-
       "should not send an email if there is not one in the session" in {
         PayApiStub.stubForFindBySessionId2xx(TestJourneys.PfSa.journeyAfterSucceedDebitWebPayment)
         val result = systemUnderTest.renderPage(fakeGetRequest)
         status(result) shouldBe Status.OK
-        EmailStub.verifyEmailWasNotSend()
+        EmailStub.verifyEmailWasNotSent()
       }
 
         def testSummaryRows(testData: Journey[JourneySpecificData], fakeRequest: FakeRequest[_], expectedSummaryListRows: List[(String, String)]) = {

--- a/test/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentStatusControllerSpec.scala
+++ b/test/uk/gov/hmrc/cardpaymentfrontend/controllers/PaymentStatusControllerSpec.scala
@@ -84,14 +84,6 @@ class PaymentStatusControllerSpec extends ItSpec {
       }
 
     }
-
-    "paymentStatus" - {
-      "should throw an error when we can't find the transaction reference in the journey, despite the payment having been started" in {
-        PayApiStub.stubForFindBySessionId2xx(TestJourneys.PfSa.journeyBeforeBeginWebPayment)
-        val error = intercept[RuntimeException] (systemUnderTest.paymentStatus()(fakeRequest).futureValue)
-        error.getMessage shouldBe "The future returned an exception of type: java.lang.RuntimeException, with message: Could not find transaction ref, therefore we can't auth and settle.."
-      }
-    }
   }
 
 }

--- a/test/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentServiceSpec.scala
+++ b/test/uk/gov/hmrc/cardpaymentfrontend/services/CardPaymentServiceSpec.scala
@@ -16,33 +16,45 @@
 
 package uk.gov.hmrc.cardpaymentfrontend.services
 
-import payapi.cardpaymentjourney.model.journey.{Journey, JsdPfSa}
+import payapi.cardpaymentjourney.model.journey.{Journey, JourneySpecificData, JsdPfSa}
 import payapi.corcommon.model.AmountInPence
-import play.api.mvc.AnyContentAsEmpty
+import play.api.i18n.MessagesApi
+import play.api.mvc.{AnyContent, AnyContentAsEmpty}
 import play.api.test.FakeRequest
+import uk.gov.hmrc.cardpaymentfrontend.actions.JourneyRequest
 import uk.gov.hmrc.cardpaymentfrontend.models.Languages.English
 import uk.gov.hmrc.cardpaymentfrontend.models.cardpayment._
 import uk.gov.hmrc.cardpaymentfrontend.models.payapi.{FailWebPaymentRequest, SucceedWebPaymentRequest}
 import uk.gov.hmrc.cardpaymentfrontend.models.{Address, EmailAddress}
 import uk.gov.hmrc.cardpaymentfrontend.testsupport.ItSpec
-import uk.gov.hmrc.cardpaymentfrontend.testsupport.stubs.{CardPaymentStub, PayApiStub}
+import uk.gov.hmrc.cardpaymentfrontend.testsupport.TestOps.FakeRequestOps
+import uk.gov.hmrc.cardpaymentfrontend.testsupport.stubs.{CardPaymentStub, EmailStub, PayApiStub}
 import uk.gov.hmrc.cardpaymentfrontend.testsupport.testdata.TestJourneys
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDateTime
 
+@SuppressWarnings(Array("org.wartremover.warts.ThreadSleep"))
 class CardPaymentServiceSpec extends ItSpec {
 
   val systemUnderTest: CardPaymentService = app.injector.instanceOf[CardPaymentService]
+  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
   implicit val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
-  val testJourney: Journey[JsdPfSa] = TestJourneys.PfSa.journeyBeforeBeginWebPayment
+  def fakeJourneyRequest(journey: Journey[JourneySpecificData], withEmail: Boolean): JourneyRequest[AnyContent] = {
+    if (withEmail) new JourneyRequest(journey, FakeRequest().withEmailInSession(journey._id))
+    else new JourneyRequest(journey, FakeRequest())
+  }
+
+  val testJourneyBeforeBeginWebPayment: Journey[JsdPfSa] = TestJourneys.PfSa.journeyBeforeBeginWebPayment
+  val testJourneyAfterBeginWebPayment: Journey[JsdPfSa] = TestJourneys.PfSa.journeyAfterBeginWebPayment
   val testAddress: Address = Address("made up street", postcode = "AA11AA", country = "GBR")
   val testEmail: EmailAddress = EmailAddress("some@email.com")
 
   "CardPaymentService" - {
+
     "initiatePayment" - {
       val cardPaymentInitiatePaymentRequest = CardPaymentInitiatePaymentRequest(
         redirectUrl         = "http://localhost:10155/pay-by-card/return-to-hmrc",
@@ -61,23 +73,24 @@ class CardPaymentServiceSpec extends ItSpec {
 
       "should return a CardPaymentInitiatePaymentResponse when card-payment backend returns one" in {
         CardPaymentStub.InitiatePayment.stubForInitiatePayment2xx(cardPaymentInitiatePaymentRequest, expectedCardPaymentInitiatePaymentResponse)
-        val result = systemUnderTest.initiatePayment(testJourney, testAddress, Some(testEmail), English).futureValue
+        val result = systemUnderTest.initiatePayment(testJourneyBeforeBeginWebPayment, testAddress, Some(testEmail), English).futureValue
         result shouldBe expectedCardPaymentInitiatePaymentResponse
       }
 
       "should update pay-api journey with BeginWebPaymentRequest when call to card-payment backend succeeds" in {
         CardPaymentStub.InitiatePayment.stubForInitiatePayment2xx(cardPaymentInitiatePaymentRequest, expectedCardPaymentInitiatePaymentResponse)
-        systemUnderTest.initiatePayment(testJourney, testAddress, Some(testEmail), English).futureValue
-        PayApiStub.verifyUpdateBeginWebPayment(1, testJourney._id.value)
+        systemUnderTest.initiatePayment(testJourneyBeforeBeginWebPayment, testAddress, Some(testEmail), English).futureValue
+        PayApiStub.verifyUpdateBeginWebPayment(1, testJourneyBeforeBeginWebPayment._id.value)
       }
     }
 
     "finishPayment" - {
+
       "should return Some[CardPaymentResult] when one is returned from card-payment backend" in {
         val testTime = LocalDateTime.now()
         val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Successful, AdditionalPaymentInfo(Some("debit"), Some(123), Some(testTime)))
         CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
-        val result = systemUnderTest.finishPayment("sometransactionref", testJourney._id.value).futureValue
+        val result = systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, false), messagesApi).futureValue
         result shouldBe Some(CardPaymentResult(CardPaymentFinishPaymentResponses.Successful, AdditionalPaymentInfo(Some("debit"), Some(123), Some(testTime))))
       }
 
@@ -85,23 +98,41 @@ class CardPaymentServiceSpec extends ItSpec {
         val testTime = LocalDateTime.now()
         val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Successful, AdditionalPaymentInfo(Some("debit"), Some(123), Some(testTime)))
         CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
-        systemUnderTest.finishPayment("sometransactionref", testJourney._id.value).futureValue
-        PayApiStub.verifyUpdateSucceedWebPayment(1, testJourney._id.value, testTime)
+        systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, false), messagesApi).futureValue
+        PayApiStub.verifyUpdateSucceedWebPayment(1, testJourneyAfterBeginWebPayment._id.value, testTime)
       }
 
       "should update pay-api with FailWebPaymentRequest when call to card-payment backend indicates failure" in {
         val testTime = LocalDateTime.now()
         val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Failed, AdditionalPaymentInfo(Some("debit"), None, Some(testTime)))
         CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
-        systemUnderTest.finishPayment("sometransactionref", testJourney._id.value).futureValue
-        PayApiStub.verifyUpdateFailWebPayment(1, testJourney._id.value, testTime)
+        systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, false), messagesApi).futureValue
+        PayApiStub.verifyUpdateFailWebPayment(1, testJourneyAfterBeginWebPayment._id.value, testTime)
       }
 
       "should update pay-api with CancelWebPaymentRequest when call to card-payment backend indicates Cancelled" in {
         val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Cancelled, AdditionalPaymentInfo(None, None, None))
         CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
-        systemUnderTest.finishPayment("sometransactionref", testJourney._id.value).futureValue
-        PayApiStub.verifyUpdateCancelWebPayment(1, testJourney._id.value)
+        systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, false), messagesApi).futureValue
+        PayApiStub.verifyUpdateCancelWebPayment(1, testJourneyAfterBeginWebPayment._id.value)
+      }
+
+      "should send an email when there is one in session, aswell as update pay-api when journey is in sent state" in {
+        val testTime = LocalDateTime.now(FrozenTime.clock)
+        val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Successful, AdditionalPaymentInfo(Some("debit"), Some(123), Some(testTime)))
+        CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
+        systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, true), messagesApi).futureValue
+        PayApiStub.verifyUpdateSucceedWebPayment(1, testJourneyAfterBeginWebPayment._id.value, testTime)
+        EmailStub.verifySomeEmailWasSent()
+      }
+
+      "should not send an email when there isn't one in session" in {
+        val testTime = LocalDateTime.now(FrozenTime.clock)
+        val testCardPaymentResult = CardPaymentResult(CardPaymentFinishPaymentResponses.Successful, AdditionalPaymentInfo(Some("debit"), Some(123), Some(testTime)))
+        CardPaymentStub.AuthAndCapture.stubForAuthAndCapture2xx("sometransactionref", testCardPaymentResult)
+        systemUnderTest.finishPayment("sometransactionref", testJourneyAfterBeginWebPayment._id.value)(fakeJourneyRequest(testJourneyAfterBeginWebPayment, false), messagesApi).futureValue
+        PayApiStub.verifyUpdateSucceedWebPayment(1, testJourneyAfterBeginWebPayment._id.value, testTime)
+        EmailStub.verifyEmailWasNotSent()
       }
     }
 

--- a/test/uk/gov/hmrc/cardpaymentfrontend/testsupport/stubs/EmailStub.scala
+++ b/test/uk/gov/hmrc/cardpaymentfrontend/testsupport/stubs/EmailStub.scala
@@ -26,10 +26,12 @@ object EmailStub {
 
   private val path: String = s"/hmrc/email"
 
-  def verifyEmailWasNotSend(): Unit = verify(0, postRequestedFor(urlEqualTo(path)))
+  def verifyEmailWasNotSent(): Unit = verify(0, postRequestedFor(urlEqualTo(path)))
 
   def verifyEmailWasSent(expectedRequestBody: JsValue): Unit =
     verify(1, postRequestedFor(urlEqualTo(path)).withRequestBody(equalToJson(expectedRequestBody.toString())))
+
+  def verifySomeEmailWasSent(): Unit = verify(1, postRequestedFor(urlEqualTo(path)))
 
   def stubForSendEmail(emailRequest: EmailRequest): StubMapping = stubFor(
     post(urlPathEqualTo(path)).willReturn(


### PR DESCRIPTION
- send email on success, once when we get the status back from the backend.
- add paymentStatus action refiner so we only call payment status in backend when journey status is Sent